### PR TITLE
Implement correct 2d JIT solve! 

### DIFF
--- a/diffmpm/element.py
+++ b/diffmpm/element.py
@@ -147,7 +147,7 @@ class _Element(abc.ABC):
         )
         _, self.nodes.momentum, _, _ = lax.fori_loop(0, len(particles), _step, args)
         self.nodes.momentum = jnp.where(
-            self.nodes.momentum < 1e-12,
+            jnp.abs(self.nodes.momentum) < 1e-12,
             jnp.zeros_like(self.nodes.momentum),
             self.nodes.momentum,
         )
@@ -159,7 +159,7 @@ class _Element(abc.ABC):
             self.nodes.momentum / self.nodes.mass,
         )
         self.nodes.velocity = jnp.where(
-            self.nodes.velocity < 1e-12,
+            jnp.abs(self.nodes.velocity) < 1e-12,
             jnp.zeros_like(self.nodes.velocity),
             self.nodes.velocity,
         )
@@ -301,12 +301,12 @@ class _Element(abc.ABC):
             self.nodes.mass * self.nodes.velocity
         )
         self.nodes.velocity = jnp.where(
-            self.nodes.velocity < 1e-12,
+            jnp.abs(self.nodes.velocity) < 1e-12,
             jnp.zeros_like(self.nodes.velocity),
             self.nodes.velocity,
         )
         self.nodes.acceleration = jnp.where(
-            self.nodes.acceleration < 1e-12,
+            jnp.abs(self.nodes.acceleration) < 1e-12,
             jnp.zeros_like(self.nodes.acceleration),
             self.nodes.acceleration,
         )

--- a/diffmpm/io.py
+++ b/diffmpm/io.py
@@ -117,6 +117,7 @@ class Config:
         if config["mesh"]["type"] == "generator":
             elements = element_cls(
                 config["mesh"]["nelements"],
+                jnp.product(jnp.array(config["mesh"]["nelements"])),
                 config["mesh"]["element_length"],
                 constraints,
                 concentrated_nodal_forces=self.parsed_config["external_loading"][

--- a/diffmpm/io.py
+++ b/diffmpm/io.py
@@ -27,8 +27,10 @@ class Config:
         self._parse_output(self._fileconfig)
         self._parse_materials(self._fileconfig)
         self._parse_particles(self._fileconfig)
-        self._parse_math_functions(self._fileconfig)
-        self._parse_external_loading(self._fileconfig)
+        if "math_functions" in self._fileconfig:
+            self._parse_math_functions(self._fileconfig)
+        if "external_loading" in self._fileconfig:
+            self._parse_external_loading(self._fileconfig)
         mesh = self._parse_mesh(self._fileconfig)
         return mesh
 
@@ -78,33 +80,39 @@ class Config:
     def _parse_external_loading(self, config):
         external_loading = {}
         external_loading["gravity"] = jnp.array(config["external_loading"]["gravity"])
-        cnf_list = []
-        for cnfconfig in config["external_loading"]["concentrated_nodal_forces"]:
-            if "math_function_id" in cnfconfig:
-                fn = self.parsed_config["math_functions"][cnfconfig["math_function_id"]]
-            else:
-                fn = Unit(-1)
-            cnf = NodalForce(
-                node_ids=jnp.array(cnfconfig["node_ids"]),
-                function=fn,
-                dir=cnfconfig["dir"],
-                force=cnfconfig["force"],
-            )
-            cnf_list.append(cnf)
+        external_loading["concentrated_nodal_forces"] = []
+        external_loading["particle_surface_traction"] = []
+        if "concentrated_nodal_forces" in config["external_loading"]:
+            cnf_list = []
+            for cnfconfig in config["external_loading"]["concentrated_nodal_forces"]:
+                if "math_function_id" in cnfconfig:
+                    fn = self.parsed_config["math_functions"][
+                        cnfconfig["math_function_id"]
+                    ]
+                else:
+                    fn = Unit(-1)
+                cnf = NodalForce(
+                    node_ids=jnp.array(cnfconfig["node_ids"]),
+                    function=fn,
+                    dir=cnfconfig["dir"],
+                    force=cnfconfig["force"],
+                )
+                cnf_list.append(cnf)
+            external_loading["concentrated_nodal_forces"] = cnf_list
 
-        pst_list = []
-        for pstconfig in config["external_loading"]["particle_surface_traction"]:
-            pst = ParticleTraction(
-                pset=jnp.array(pstconfig["pset"]),
-                function=self.parsed_config["math_functions"][
-                    pstconfig["math_function_id"]
-                ],
-                dir=pstconfig["dir"],
-                traction=pstconfig["traction"],
-            )
-            pst_list.append(pst)
-        external_loading["concentrated_nodal_forces"] = cnf_list
-        external_loading["particle_surface_traction"] = pst_list
+        if "particle_surface_traction" in config["external_loading"]:
+            pst_list = []
+            for pstconfig in config["external_loading"]["particle_surface_traction"]:
+                pst = ParticleTraction(
+                    pset=jnp.array(pstconfig["pset"]),
+                    function=self.parsed_config["math_functions"][
+                        pstconfig["math_function_id"]
+                    ],
+                    dir=pstconfig["dir"],
+                    traction=pstconfig["traction"],
+                )
+                pst_list.append(pst)
+            external_loading["particle_surface_traction"] = pst_list
         self.parsed_config["external_loading"] = external_loading
 
     def _parse_mesh(self, config):

--- a/diffmpm/particle.py
+++ b/diffmpm/particle.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 import jax.numpy as jnp
+from functools import partial
 from jax import jit, vmap, lax
 import jax.debug as db
 from jax.tree_util import register_pytree_node_class
@@ -144,9 +145,10 @@ class Particles:
             )
         self.volume = jnp.divide(self.mass, self.material.properties["density"])
 
-    def compute_volume(self, elements: _Element):
-        elements.compute_volume()
-        particles_per_element = jnp.bincount(self.element_ids, length=len(elements.ids))
+    def compute_volume(self, elements, total_elements):
+        particles_per_element = jnp.bincount(
+            self.element_ids, length=elements.total_elements
+        )
         vol = (
             elements.volume.squeeze((1, 2))[self.element_ids]
             / particles_per_element[self.element_ids]

--- a/examples/mpm-nodal-forces.toml
+++ b/examples/mpm-nodal-forces.toml
@@ -16,7 +16,7 @@ type = "MPMExplicit"
 dimension = 2
 scheme = "usf"
 dt = 0.001
-nsteps = 20
+nsteps = 301
 velocity_update = true
 
 [output]
@@ -59,7 +59,7 @@ gravity = [0, 0]
 node_ids = [3, 7]
 math_function_id = 0
 dir = 0
-force = 0.01
+force = 0.05
 
 [[external_loading.particle_surface_traction]]
 pset = [1]

--- a/examples/simple_2d.py
+++ b/examples/simple_2d.py
@@ -26,15 +26,17 @@ cons = [
 
 mathfn = Linear(0, jnp.array([0.0, 0.5, 1.0]), jnp.array([0.0, 1.0, 1.0]))
 cnf = [NodalForce(jnp.array([0, 1]), mathfn, 1, 10)]
-elements = Quadrilateral4Node((1, 1), (1.0, 1.0), cons, concentrated_nodal_forces=cnf)
-elements.nodes.velocity = elements.nodes.velocity.at[:, :, 0].set(1)
+elements = Quadrilateral4Node(
+    (1, 1), 1, (1.0, 1.0), cons, concentrated_nodal_forces=cnf
+)
+# elements.nodes.velocity = elements.nodes.velocity.at[:, :, 0].set(1)
 # elements.nodes.mass += 1
 # elements.compute_external_force(particles)
 # print(elements.nodes.f_ext.squeeze())
 # elements.compute_body_force(particles, jnp.array([0, -10]).reshape(1, 2))
 # elements.compute_internal_force(particles)
 mesh = Mesh2D({"elements": elements, "particles": [particles]})
-mpm = MPMExplicit(mesh, 0.01, scheme="usf")
+mpm = MPMExplicit(mesh, 0.01, scheme="usf", velocity_update=True)
 result = mpm.solve(10, 0)
 # breakpoint()
-print(result["stress"][10, :, :2, 0])
+print(result["stress"][-1])

--- a/examples/simple_2d_file.py
+++ b/examples/simple_2d_file.py
@@ -6,7 +6,7 @@ from diffmpm.solver import MPM
 mpm = MPM(sys.argv[1])
 result = mpm.solve()
 # breakpoint()
-print(result["stress"][-1])
+print(result["stress"][-1][:, :2])
 exit()
 
 


### PR DESCRIPTION
We now have working 2D JIT solvers! Compared results on the `uniaxial_stress` 

To correct the 2D JIT solve with correct volume computation, 2 major changes were made:
1. The elements class constructor now takes the total number of elements as an argument along with number of elements in both directions. This is so that `jnp.bincount` can work correctly without having to pass a tracer value to its `length` parameter.
2. Update the `MPMExplicit` flattening/unflattening to include the `velocity_update` parameter to make it work with JIT.